### PR TITLE
clipboard: suppression exit warning if exit code is >= 128

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -25,7 +25,8 @@ function! s:selection.on_exit(jobid, data, event) abort
   if self.owner == a:jobid
     let self.owner = 0
   endif
-  if a:data != 0
+  " Don't print if exit code is >= 128 ( exit is 128+SIGNUM if by signal (e.g. 143 on SIGTERM))
+  if a:data > 0 && a:data < 128
     echohl WarningMsg
     echomsg 'clipboard: error invoking '.get(self.argv, 0, '?').': '.join(self.stderr)
     echohl None


### PR DESCRIPTION
This is a matching change to https://github.com/neovim/neovim/commit/939d9053bdf2f56286640c581eb4e2ff5a856540

Fixes: #7054